### PR TITLE
fix: PySide 6.11 无边框窗口有未知阴影

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 opencv-python>=4.8.0
 numpy>=1.24.0
 mss>=9.0.1
-PySide6>=6.10.0
+PySide6>=6.10.0,<6.11
 customtkinter>=5.2.0
 pywin32>=306
 pydirectinput>=1.0.4


### PR DESCRIPTION
在 PySide6 6.11.0 中，设置了 FramelessWindowHint 后窗口反而多了一圈灰色边框

这是 PySide6 6.11.0 版本引入的一个已知问题，详见 [Possible regression in PySide 6.11 with WindowFlags Frameless and pyinstaller?](https://forum.pythonguis.com/t/possible-regression-in-pyside-6-11-with-windowflags-frameless-and-pyinstaller/2144)

可临时降级到 6.10.x，命令如下：

```bash
pip uninstall PySide6 PySide6_Addons PySide6_Essentials
pip install PySide6<6.11 PySide6_Addons<6.11 PySide6_Essentials<6.11
```