### PR TITLE
fix(state_machine): 修复结算检测被初始界面 F 键误挡导致卡死

### DIFF
--- a/core/_sm_result_detector.py
+++ b/core/_sm_result_detector.py
@@ -74,8 +74,21 @@ class ResultDetector:
                     "roi": roi,
                 }
             if loc is not None:
+                tmpl_name = Path(matched_path).name if matched_path else "?"
+                self._sm._throttled_log(
+                    f"signal_hit_{kind}",
+                    f"[偵測] {kind} 命中: 信度 {conf:.2f}/{threshold:.2f} (策略={strategy}, 模板={tmpl_name})",
+                    interval=0.5,
+                )
                 return best
 
+        if best is not None:
+            tmpl_name = Path(best.get("template") or "").name or "?"
+            self._sm._throttled_log(
+                f"signal_miss_{kind}",
+                f"[偵測] {kind} 未達阈值: 最佳信度 {best['confidence']:.2f}/{threshold:.2f} (策略={best.get('strategy')}, 模板={tmpl_name})",
+                interval=1.0,
+            )
         return None
 
     def build_success_result_info(self, success_signals):
@@ -88,11 +101,79 @@ class ResultDetector:
             "signals": success_signals,
         }
 
+    def quick_settlement_signal_present(self, rect):
+        if self._sm.sc is None or not rect:
+            return None
+        probes = (
+            ("close-hint", self._sm.tpl.success_close_prompt_templates(), (0.22, 0.76, 0.56, 0.20), 0.66),
+            ("g-hint",     self._sm.tpl.weight_unit_templates(),          (0.30, 0.56, 0.42, 0.22), 0.62),
+            ("exp-hint",   self._sm.tpl.success_exp_templates(),          (0.24, 0.48, 0.52, 0.25), 0.58),
+        )
+        for tag, templates, roi, thresh in probes:
+            if not templates:
+                continue
+            img = self._sm.sc.capture_relative(rect, *roi)
+            if img is None:
+                continue
+            loc, conf, matched_path, strategy = self._sm.vis.find_best_template_multi_strategy(
+                img,
+                templates,
+                ({"name": f"{tag}-plain", "threshold": thresh},),
+                threshold=thresh,
+                scale_range=self._sm.tpl.scale_range(rect, 0.70, 1.40),
+                scale_steps=5,
+            )
+            if loc:
+                return {
+                    "tag": tag,
+                    "confidence": conf,
+                    "template": matched_path,
+                    "strategy": strategy,
+                }
+        return None
+
+    def initial_ui_blocks_result_detection(self, rect, threshold=0.88):
+        f_info = self._sm.cast_det.detect_initial_f_prompt_quick(rect, threshold=threshold)
+        if not f_info:
+            return False
+        cluster = self._sm.cast_det.detect_initial_control_cluster(rect)
+        f_conf = float(f_info.get("confidence") or 0.0)
+        if not (cluster and cluster.get("valid", False)):
+            cluster_count = int((cluster or {}).get("count") or 0)
+            self._sm._throttled_log(
+                "guard_pass",
+                f"[結算/守門員] F={f_conf:.2f} 但 cluster 未通過驗證(count={cluster_count}) → 放行偵測",
+                interval=1.0,
+            )
+            return False
+
+        settlement_hint = self.quick_settlement_signal_present(rect)
+        if settlement_hint:
+            tag = settlement_hint.get("tag", "?")
+            s_conf = float(settlement_hint.get("confidence") or 0.0)
+            tmpl_name = Path(settlement_hint.get("template") or "").name or "?"
+            self._sm._throttled_log(
+                "guard_bypass_settlement",
+                f"[結算/守門員] F+cluster 命中,但同步出現結算正面信號 {tag}={s_conf:.2f} ({tmpl_name}) → bypass 守門員",
+                interval=1.0,
+            )
+            return False
+
+        keys = "+".join(m.get("key", "?") for m in cluster.get("matches", [])) or "?"
+        self._sm._throttled_log(
+            "guard_block",
+            f"[結算/守門員] 判定為初始介面已跳過偵測: F={f_conf:.2f} cluster=valid({keys})",
+            interval=1.0,
+        )
+        return True
+
     # ------------------------------------------------------------------ #
     #  成功 / 失败检测（按速度分层）
     # ------------------------------------------------------------------ #
 
     def detect_ultrafast_success_result(self, rect):
+        if self.initial_ui_blocks_result_detection(rect, threshold=0.88):
+            return None
         close_info = self.match_result_signal(
             rect,
             "click close prompt",
@@ -101,14 +182,14 @@ class ResultDetector:
                 (0.22, 0.76, 0.56, 0.20),
             ),
             (
-                {"name": "close-ultra-edge", "threshold": 0.70, "use_edge": True, "early_accept": 0.92},
+                {"name": "close-ultra-plain", "threshold": 0.86, "early_accept": 0.94},
             ),
-            threshold=0.70,
+            threshold=0.86,
             low_factor=0.82,
             high_factor=1.24,
             scale_steps=5,
         )
-        if close_info and close_info.get("location") and close_info.get("confidence", 0.0) >= 0.84:
+        if close_info and close_info.get("location") and close_info.get("confidence", 0.0) >= 0.92:
             return self.build_success_result_info([close_info])
 
         exp_info = self.match_result_signal(
@@ -148,7 +229,7 @@ class ResultDetector:
         return None
 
     def detect_fast_success_result(self, rect, fast_only=False):
-        if self._sm._detect_initial_f_prompt_quick(rect, threshold=0.88):
+        if self.initial_ui_blocks_result_detection(rect, threshold=0.88):
             return None
         ultra_info = self.detect_ultrafast_success_result(rect)
         if ultra_info and ultra_info.get("location"):
@@ -165,10 +246,9 @@ class ResultDetector:
                 (0.18, 0.74, 0.64, 0.24),
             ),
             (
-                {"name": "close-fast-edge", "threshold": 0.66, "use_edge": True},
-                {"name": "close-fast-plain", "threshold": 0.74},
+                {"name": "close-fast-plain", "threshold": 0.82},
             ),
-            threshold=0.66,
+            threshold=0.82,
             low_factor=0.62,
             high_factor=1.50,
             scale_steps=11,
@@ -240,8 +320,8 @@ class ResultDetector:
             scale_steps=5,
         )
 
-    def detect_success_result(self, rect):
-        if self._sm._detect_initial_f_prompt_quick(rect, threshold=0.88):
+    def detect_success_result(self, rect, bypass_guard=False):
+        if not bypass_guard and self.initial_ui_blocks_result_detection(rect, threshold=0.88):
             return None
 
         success_signals = []
@@ -278,10 +358,9 @@ class ResultDetector:
                 (0.30, 0.82, 0.40, 0.14),
             ),
             (
-                {"name": "close-edge", "threshold": 0.50, "use_edge": True},
-                {"name": "close-plain", "threshold": 0.62},
+                {"name": "close-plain", "threshold": 0.78},
             ),
-            threshold=0.60,
+            threshold=0.78,
             low_factor=0.52,
             high_factor=1.80,
             scale_steps=17,

--- a/core/state_machine.py
+++ b/core/state_machine.py
@@ -128,6 +128,16 @@ class StateMachine:
         else:
             print(msg)
 
+    def _throttled_log(self, key, msg, interval=1.0):
+        now = time.time()
+        store = getattr(self, "_log_throttle_store", None)
+        if store is None:
+            store = {}
+            self._log_throttle_store = store
+        if now - store.get(key, 0) >= interval:
+            store[key] = now
+            self._log(msg)
+
     def _should_stop(self):
         return bool(getattr(self, "_stop_requested", False) or not getattr(self, "is_running", False))
 
@@ -579,8 +589,19 @@ class StateMachine:
                         return
                     self._wait_after_cast(rect, 1.40)
                     return
-                self._log("[等待] 多次重试后仍停留在初始钓鱼界面，进入恢复流程。")
-                self._enter_recovering("多次重发 F 后仍未进入抛竿流程", record_empty=False, press_esc=False)
+                self._log(f"[等待] 已重试 {max_retries} 次仍停留在初始钓鱼界面，最后再做一次结算判定 (bypass 守门员)。")
+                success_info = self.result_det.detect_success_result(rect, bypass_guard=True)
+                if success_info and success_info.get("location"):
+                    s_conf = float(success_info.get("confidence") or 0.0)
+                    signals = self.result_det.format_success_signals(success_info)
+                    self._log(f"[等待] 最终判定命中成功结算 (置信度: {s_conf:.2f}, 信号: {signals})，转入结算流程。")
+                    self.result_det.finish_fast_success_result(rect, success_info, source_label="等待")
+                    return
+                failed_info = self.result_det.detect_fast_failed_result(rect)
+                if self.result_det.maybe_finish_failed_result(rect, failed_info, source_label="等待"):
+                    return
+                self._log("[等待] 最终结算判定未命中，疑似卡死在结算/初始界面之间，进入恢复流程并尝试 ESC 脱困。")
+                self._enter_recovering("多次重发 F 后仍未进入抛竿流程", record_empty=False, press_esc=True)
                 return
 
 


### PR DESCRIPTION
之前版本1.3.0 detect_fast_success_result / detect_success_result 只用 _detect_initial_f_prompt_quick 单一信号守门, 但结算界面右下角的 F 键会和初始钓鱼界面的 F 键视觉上重叠,导致结算被误判为初始界面而不进入结算流程, 最终卡在等待状态死循环,玩家被迫手动 ESC。

- 新增 ResultDetector.initial_ui_blocks_result_detection 守门员: F + Q/E/R cluster 双重验证, 并在两者皆命中时再做一次结算正面信号 (close/g/exp) 探测,只要有任一结算信号即 bypass 守门员
- 新增 ResultDetector.quick_settlement_signal_present: 以宽松阈值快速探测三种结算专属模板
- detect_ultrafast/fast/success_result 改用新守门员,detect_success_result 新增 bypass_guard 参数
- ~~_handle_waiting 等待 stuck 时: 重试上限 2 -> 3 次,~~ 維持2次.最后再做一次 bypass 守门员的结算判定, 失败才进入恢复流程并主动尝试 ESC 脱困,避免卡死
- close 模板停用 edge 比对 (边缘模板在游戏背景上误报率较高),改用更严格的 plain 阈值: ultra 0.86, fast 0.82, normal 0.78
- match_result_signal 增加节流诊断日志 (命中/未达阈值),便于排查识别问题


- _sm_result_detector.py 原本调用 self._sm._detect_initial_f_prompt_quick 但 StateMachine 會出錯,顺带修复了

新增 StateMachine._throttled_log 辅助方法,为节流诊断日志提供基础设施。